### PR TITLE
Scaffold watch app and FastAPI backend

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -18,6 +18,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install SwiftLint
+        run: brew install swiftlint
+
+      - name: Run SwiftLint
+        run: swiftlint --strict --quiet
+
       - name: Install CocoaPods
         run: |
           brew install cocoapods || true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
     hooks:
       - id: mypy
         args: ["--python-version=3.13"]
+        additional_dependencies: [fastapi]
 
   - repo: local
     hooks:

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,78 @@
-"""Public module. Agents: Delete and replace this doc-string when beginning coding."""
+"""FastAPI backend providing self-care recommendations for each archetypal phase."""
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+
+app = FastAPI(title="Wavelength Backend")
+
+# Allow local development requests from the SwiftUI app
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Hard-coded recommendations for the MVP
+PHASE_RECOMMENDATIONS: dict[str, list[str]] = {
+    "Restoration": [
+        "Taking a Bath",
+        "Getting some Sunshine",
+        "Somatic Meditation",
+        "Biking",
+        "Dancing",
+    ],
+    "Rising": [
+        "Wim Hof Method",
+        "Dog Walkin Shamanism",
+        "Deep Conversation",
+        "Yoga",
+        "Creative Writing",
+    ],
+    "Peaking": [
+        "Magick",
+        "Micro-Retreats",
+        "Confidence Practice",
+        "Kombucha",
+        "Making Music",
+    ],
+    "Withdrawal": [
+        "5-4-3-2-1 Technique",
+        "Intense Exercise",
+        "4/7/8 Breathing",
+        "Box Breathing",
+    ],
+    "Diminishing": [
+        "Long Drives",
+        "Hot Beverages",
+        "Walking",
+        "Journaling",
+    ],
+    "Bottoming Out": [
+        "Getting Comfy",
+        "Drinking Water",
+        "Listening to Music",
+        "Lion's Breath",
+    ],
+}
 
 
-def hello_world() -> str:
-    """Gotta start somewhere..."""
-    return "hello world"
+@app.get("/phase/{name}")
+async def get_phase(name: str) -> dict[str, list[str] | str]:
+    """Return recommendations for a given phase.
+
+    Parameters
+    ----------
+    name:
+        Name of the phase provided by the watch app.
+
+    """
+    key = name.title()
+    if key not in PHASE_RECOMMENDATIONS:
+        raise HTTPException(status_code=404, detail="Unknown phase")
+
+    return {"phase": key, "recommendations": PHASE_RECOMMENDATIONS[key]}
+
+
+__all__ = ["app"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+httpx

--- a/backend/tests/test_phase_endpoint.py
+++ b/backend/tests/test_phase_endpoint.py
@@ -1,0 +1,22 @@
+"""Tests for the phase recommendation endpoint."""
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+client = TestClient(app)
+
+
+def test_get_phase_returns_recommendations() -> None:
+    """Known phases return a list of recommendations."""
+    response = client.get("/phase/Restoration")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["phase"] == "Restoration"
+    assert len(data["recommendations"]) > 0
+
+
+def test_get_phase_unknown_phase() -> None:
+    """Unknown phase names return a 404 error."""
+    response = client.get("/phase/Unknown")
+    assert response.status_code == 404

--- a/backend/tests/test_smoke.py
+++ b/backend/tests/test_smoke.py
@@ -1,8 +1,0 @@
-"""Smoke test! Agents: Delete and replace this doc-string when beginning coding."""
-
-from backend.main import hello_world
-
-
-def test_smoke() -> None:
-    """Necessary to get tests to pass with 100% coverage for pytest-cov."""
-    assert hello_world() == "hello world"

--- a/frontend/Package.swift
+++ b/frontend/Package.swift
@@ -1,14 +1,21 @@
 // swift-tools-version: 6.0
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
 import PackageDescription
 
 let package = Package(
-    name: "frontend",
+    name: "WavelengthWatchApp",
+    platforms: [
+        .watchOS(.v10)
+    ],
+    products: [
+        .executable(
+            name: "WavelengthWatchApp",
+            targets: ["WavelengthWatchApp"]
+        )
+    ],
     targets: [
-        // Targets are the basic building blocks of a package, defining a module or a test suite.
-        // Targets can depend on other targets in this package and products from dependencies.
         .executableTarget(
-            name: "frontend"),
+            name: "WavelengthWatchApp",
+            path: "Sources/WavelengthWatchApp"
+        )
     ]
 )

--- a/frontend/Sources/WavelengthWatchApp/ContentView.swift
+++ b/frontend/Sources/WavelengthWatchApp/ContentView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/// Main view displaying the six phases as a horizontally scrollable list.
+struct ContentView: View {
+    private let phases = [
+        "Restoration",
+        "Rising",
+        "Peaking",
+        "Withdrawal",
+        "Diminishing",
+        "Bottoming Out",
+    ]
+    @State private var selection = 0
+
+    private var loopedPhases: [String] {
+        phases + phases + phases
+    }
+
+    var body: some View {
+        TabView(selection: $selection) {
+            ForEach(loopedPhases.indices, id: \.self) { index in
+                PhaseView(phase: loopedPhases[index])
+                    .tag(index)
+            }
+        }
+        .tabViewStyle(.page)
+        .onAppear {
+            selection = phases.count
+        }
+        .onChange(of: selection) { newValue in
+            let count = phases.count
+            if newValue < count {
+                selection += count
+            } else if newValue >= count * 2 {
+                selection -= count
+            }
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/frontend/Sources/WavelengthWatchApp/PhaseView.swift
+++ b/frontend/Sources/WavelengthWatchApp/PhaseView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+/// View for a single phase. Tapping the phase name fetches recommendations
+/// from the FastAPI backend and displays them in a list.
+struct PhaseView: View {
+    let phase: String
+    @State private var recommendations: [String] = []
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Text(phase)
+                .font(.headline)
+                .onTapGesture {
+                    fetchRecommendations(for: phase)
+                }
+            Image(systemName: "arrow.right")
+                .foregroundStyle(.secondary)
+
+            if !recommendations.isEmpty {
+                List(recommendations, id: \.self) { item in
+                    Text(item)
+                }
+            }
+        }
+        .padding()
+    }
+
+    private func fetchRecommendations(for phase: String) {
+        guard let url = URL(string: "http://localhost:8000/phase/\(phase)") else {
+            return
+        }
+
+        URLSession.shared.dataTask(with: url) { data, _, _ in
+            guard
+                let data = data,
+                let response = try? JSONDecoder().decode(PhaseResponse.self, from: data)
+            else { return }
+
+            DispatchQueue.main.async {
+                recommendations = response.recommendations
+            }
+        }.resume()
+    }
+}
+
+private struct PhaseResponse: Decodable {
+    let phase: String
+    let recommendations: [String]
+}
+
+#Preview {
+    PhaseView(phase: "Restoration")
+}

--- a/frontend/Sources/WavelengthWatchApp/WavelengthWatchAppApp.swift
+++ b/frontend/Sources/WavelengthWatchApp/WavelengthWatchAppApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct WavelengthWatchAppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/frontend/Sources/main.swift
+++ b/frontend/Sources/main.swift
@@ -1,4 +1,0 @@
-// The Swift Programming Language
-// https://docs.swift.org/swift-book
-
-print("Hello, world!")


### PR DESCRIPTION
## Summary
- move runtime dependencies into requirements.txt
- refresh phase recommendations and normalise lookup casing
- loop phase pager for an infinite scroll experience
- run SwiftLint in watch CI

## Testing
- `.venv/bin/pre-commit run --files .github/workflows/frontend.yml`
- `.venv/bin/pytest backend/tests/test_phase_endpoint.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4edcbf1c083229b3855d7771eef83