### PR TITLE
Handle missing SwiftUI and SwiftLint in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,4 +39,3 @@ repos:
         entry: swiftlint
         language: system
         types: [swift]
-        additional_dependencies: []

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
-# Install SwiftLint
-if ! command -v swiftlint &> /dev/null
-then
-    echo "Installing SwiftLint via Homebrew..."
-    brew install swiftlint
+# Install SwiftLint if not already installed
+if ! command -v swiftlint &> /dev/null; then
+    echo "Installing SwiftLint..."
+    if command -v brew &> /dev/null; then
+        brew install swiftlint
+    else
+        curl -L -o swiftlint_linux.zip https://github.com/realm/SwiftLint/releases/download/0.59.1/swiftlint_linux.zip
+        unzip -o swiftlint_linux.zip swiftlint -d swiftlint_bin
+        install swiftlint_bin/swiftlint /usr/local/bin
+        rm -rf swiftlint_bin swiftlint_linux.zip
+    fi
 fi
 
 echo "🔧 Creating virtual environment..."

--- a/frontend/Sources/WavelengthWatchApp/ContentView.swift
+++ b/frontend/Sources/WavelengthWatchApp/ContentView.swift
@@ -1,3 +1,7 @@
+// This file relies on SwiftUI. When SwiftUI isn't available (such as in
+// Linux environments used in CI), the entire view is skipped so that the
+// Swift package can still be built and other checks can run.
+#if canImport(SwiftUI)
 import SwiftUI
 
 /// Main view displaying the six phases as a horizontally scrollable list.
@@ -41,3 +45,4 @@ struct ContentView: View {
 #Preview {
     ContentView()
 }
+#endif

--- a/frontend/Sources/WavelengthWatchApp/PhaseView.swift
+++ b/frontend/Sources/WavelengthWatchApp/PhaseView.swift
@@ -1,3 +1,6 @@
+// This view depends on SwiftUI. Wrap it so Linux builds succeed even when
+// SwiftUI isn't present.
+#if canImport(SwiftUI)
 import SwiftUI
 
 /// View for a single phase. Tapping the phase name fetches recommendations
@@ -51,3 +54,4 @@ private struct PhaseResponse: Decodable {
 #Preview {
     PhaseView(phase: "Restoration")
 }
+#endif

--- a/frontend/Sources/WavelengthWatchApp/WavelengthWatchAppApp.swift
+++ b/frontend/Sources/WavelengthWatchApp/WavelengthWatchAppApp.swift
@@ -1,3 +1,5 @@
+// The main app entry point relies on SwiftUI. Provide a lightweight fallback
+#if canImport(SwiftUI)
 import SwiftUI
 
 @main
@@ -8,3 +10,13 @@ struct WavelengthWatchAppApp: App {
         }
     }
 }
+#else
+@main
+struct WavelengthWatchAppApp {
+    static func main() {
+        // Running on a platform without SwiftUI (e.g., Linux). The executable
+        // does nothing, but building succeeds so other checks can run.
+        print("SwiftUI not available; skipping watch app launch.")
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Install SwiftLint automatically in dev setup and require the hook
- Keep SwiftUI code guarded so non-Apple builds succeed

## Testing
- `pytest`
- `swift build -c release --package-path frontend`
- `pre-commit run --files dev-setup.sh .pre-commit-config.yaml frontend/Sources/WavelengthWatchApp/ContentView.swift frontend/Sources/WavelengthWatchApp/PhaseView.swift frontend/Sources/WavelengthWatchApp/WavelengthWatchAppApp.swift`


------
https://chatgpt.com/codex/tasks/task_e_68a8175423708322bf7a4958b799af76