### PR TITLE
test: migrate phase endpoint tests to unittest

### DIFF
--- a/backend/tests/test_phase_endpoint.py
+++ b/backend/tests/test_phase_endpoint.py
@@ -1,22 +1,38 @@
 """Tests for the phase recommendation endpoint."""
 
+import unittest
+
 from fastapi.testclient import TestClient
 
-from backend.main import app
-
-client = TestClient(app)
+from backend.main import PHASE_RECOMMENDATIONS, app
 
 
-def test_get_phase_returns_recommendations() -> None:
-    """Known phases return a list of recommendations."""
-    response = client.get("/phase/Restoration")
-    assert response.status_code == 200
-    data = response.json()
-    assert data["phase"] == "Restoration"
-    assert len(data["recommendations"]) > 0
+class PhaseEndpointTests(unittest.TestCase):
+    """Ensure phase endpoints behave as expected."""
+
+    def setUp(self) -> None:  # noqa: D401
+        """Create a test client for the app."""
+        self.client = TestClient(app)
+
+    def test_get_phase_returns_recommendations(self) -> None:
+        """Each defined phase returns a non-empty list of recommendations."""
+        for phase in PHASE_RECOMMENDATIONS:
+            with self.subTest(phase=phase):
+                response = self.client.get(f"/phase/{phase}")
+                self.assertEqual(response.status_code, 200)
+                data = response.json()
+                self.assertEqual(data["phase"], phase)
+                self.assertTrue(
+                    data["recommendations"], "Expected at least one recommendation"
+                )
+
+    def test_get_phase_unknown_phase(self) -> None:
+        """Unknown phase names return a 404 error."""
+        for phase in ["Unknown", "Nonexistent"]:
+            with self.subTest(phase=phase):
+                response = self.client.get(f"/phase/{phase}")
+                self.assertEqual(response.status_code, 404)
 
 
-def test_get_phase_unknown_phase() -> None:
-    """Unknown phase names return a 404 error."""
-    response = client.get("/phase/Unknown")
-    assert response.status_code == 404
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ line_length = 88
 [tool.ruff]
 line-length = 88
 target-version = "py312"
-lint.extend-select = ["E", "F", "W", "I", "D", "UP", "B", "SIM"]
+lint.extend-select = ["E", "F", "W", "I", "D", "UP", "B", "SIM", "S"]
 lint.ignore = ["D203", "D213"]
 fix = true
 
@@ -18,8 +18,6 @@ addopts = "-q --strict-markers --disable-warnings --maxfail=1 --cov=."
 testpaths = ["backend/tests"]
 python_files = "test_*.py"
 pythonpath = ["."]
-
-
 [tool.coverage.run]
 branch = true
 source = ["."]


### PR DESCRIPTION
## Summary
- rewrite phase endpoint tests using unittest with subtests
- enable ruff security checks to disallow asserts
- restore pytest configuration in pyproject

## Testing
- `pre-commit run --all-files` *(fails: SwiftLint executable not found)*
- `SKIP=swiftlint pre-commit run --all-files`
- `python -m unittest discover -s backend/tests -v`


------
https://chatgpt.com/codex/tasks/task_e_68a8192664908322ab60f61b2dd74c62